### PR TITLE
Fixed check empty sections and categories

### DIFF
--- a/controllers/Seo_SitemapController.php
+++ b/controllers/Seo_SitemapController.php
@@ -36,7 +36,7 @@ class Seo_SitemapController extends BaseController
 	{
 		$urls = [];
 
-		if (array_key_exists('sections', $this->sitemap)) {
+		if (array_key_exists('sections', $this->sitemap) && !empty($this->sitemap['sections'])) {
 			foreach ($this->sitemap['sections'] as $sectionId => $section)
 			{
 				if ($section['enabled'])
@@ -51,7 +51,7 @@ class Seo_SitemapController extends BaseController
 	{
 		$urls = [];
 
-		if (array_key_exists('categories', $this->sitemap)) {
+		if (array_key_exists('categories', $this->sitemap) && !empty($this->sitemap['categories'])) {
 			foreach ($this->sitemap['categories'] as $categoryId => $category)
 			{
 				if ($category['enabled'])


### PR DESCRIPTION
In devMode this will throw an error "Invalid argument supplied for foreach()" when you not have configured sections or categories.