### PR TITLE
Fixed the returning #20 php error.

### DIFF
--- a/seo/services/Seo_SitemapService.php
+++ b/seo/services/Seo_SitemapService.php
@@ -39,6 +39,7 @@ class Seo_SitemapService extends BaseApplicationComponent
 		{
 			foreach ((array)$rows as $new)
 			{
+				if (!is_array($new)) continue;
 				$new['group'] = $group;
 
 				if (!array_key_exists('id', $new)) continue;


### PR DESCRIPTION
When categories or custom urls is empty, they return a string instead
of an array.