### PR TITLE
Secondary fix #38

### DIFF
--- a/seo/controllers/SeoController.php
+++ b/seo/controllers/SeoController.php
@@ -62,7 +62,7 @@ class SeoController extends BaseController
 		$namespace = 'data';
 
 		craft()->templates->includeJsResource('seo/js/seo-settings.min.js');
-		craft()->templates->includeJs("new SeoSettings('{$namespace}', 'sitemap');");
+		craft()->templates->includeJs("new SeoSettings('{$namespace}', 'sitemap', [Craft.csrfTokenName, Craft.csrfTokenValue]);");
 
 		$this->renderTemplate('seo/sitemap', array(
 			// Global


### PR DESCRIPTION
secondary update for #38 as sitemap has it's own JS output which was also missing the CSRF token pull from Craft's JS array

---

Sorry guys, I missed the fact that both `actionSettings` and `actionSitemapPage` methods were missing the CSRF variables in that file. This updates the fixes for the fix on Sitemap page, the other pages don't display the error thanks to the earlier fix.