### PR TITLE
Added return;

### DIFF
--- a/resources/js/field/KeywordChecklist.js
+++ b/resources/js/field/KeywordChecklist.js
@@ -294,6 +294,7 @@ export default class KeywordChecklist {
 				SEO_RATING.GOOD,
 				SEO_REASONS.firstParagraphSuccess
 			);
+			return;
 		}
 		
 		this.addRating(


### PR DESCRIPTION
If an entry passes `judgeFirstParagraph()`, both a positive and a negative rating are added since there's a `return;` missing.