### PR TITLE
isset check for expiryDate in injectRobots

### DIFF
--- a/src/services/SeoService.php
+++ b/src/services/SeoService.php
@@ -47,10 +47,12 @@ class SeoService extends Component
 						$robots,
 						$variable->{$field->handle}['advanced']['robots']
 					);
-
+			
 			/** @var \DateTime $expiry */
-			if ($expiry = $variable->expiryDate)
-				$expiry = $expiry->format(\DATE_RFC850);
+			if (isset($variable->expiryDate))
+				$expiry = $variable->expiryDate->format(\DATE_RFC850);
+			else
+				$expiry = null;
 		}
 
 		// If we don't have any variables (i.e. when just rendering a template)


### PR DESCRIPTION
Without an isset check for expiryDate, a non handled 500 error can be thrown, causing craft to die.
This generally happens when the variable is not an Entry.

Changes proposed in this pull request:
Only retrieve an expiryDate when a variable has an expiryDate property.