### PR TITLE
switch to using absoluteUrl for canonical tag

### DIFF
--- a/src/templates/_seo/meta.twig
+++ b/src/templates/_seo/meta.twig
@@ -35,5 +35,5 @@
 	<meta name="twitter:image" content="{{ craft.seo.twitterImage(tw.image) }}" />
 
 	<link rel="home" href="{{ siteUrl }}" />
-	<link rel="canonical" href="{{ craft.app.request.pathInfo }}">
+	<link rel="canonical" href="{{ craft.app.request.absoluteUrl }}">
 {# SEO End #}


### PR DESCRIPTION
switch to using absoluteUrl for canonical tag so they are not misinterpreted as nested URLs and follow SEO best practices

Changes proposed in this pull request:

- meta template now outputs the absolute URL for the page rather than a relative URL