### PR TITLE
Set og:site_name to {{ seo.title }}

### DIFF
--- a/src/templates/_seo/meta.twig
+++ b/src/templates/_seo/meta.twig
@@ -20,7 +20,7 @@
 	<meta property="og:title" content="{{ fb.title }}" />
 	<meta property="og:image" content="{{ craft.seo.facebookImage(fb.image) }}" />
 	<meta property="og:description" content="{{ fb.description }}" />
-	<meta property="og:site_name" content="{{ siteName }}" />
+	<meta property="og:site_name" content="{{ seo.title }}" />
 	<meta property="og:locale" content="{{ locale }}" />
 	{% for locale in locales -%}
 		<meta property="og:locale:alternate" content="{{ locale }}" />


### PR DESCRIPTION
Sets the correct `og:site_name` meta tag.

Problem which this PR solves:

1. Create multilingual site with siteNames **English** and **German**
2. You don't want the `og:site_name` to be **English** or **German** but the site title defined in your SEO settings.