### PR TITLE
V3 multisites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "jorgeanzola/seo",
+  "name": "ether/seo",
   "license": "MIT",
   "description": "SEO utilities including a unique field type, sitemap, & redirect manager",
   "version": "3.3.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ether/seo",
+  "name": "jorgeanzola/seo",
   "license": "MIT",
   "description": "SEO utilities including a unique field type, sitemap, & redirect manager",
   "version": "3.3.0",

--- a/src/services/RedirectsService.php
+++ b/src/services/RedirectsService.php
@@ -91,6 +91,8 @@ class RedirectsService extends Component
 				$siteUrlSegments = $this->getSiteUrlSegments();
 				
 				$path = $siteUrlSegments . $path;
+				
+				$redirect['to'] = str_replace($siteUrlSegments, '', $redirect['to']);
 			}
 
 			if (trim($redirect['uri'], '/') == $path)

--- a/src/services/RedirectsService.php
+++ b/src/services/RedirectsService.php
@@ -2,6 +2,7 @@
 
 namespace ether\seo\services;
 
+use Craft;
 use craft\base\Component;
 use craft\events\ExceptionEvent;
 use craft\helpers\UrlHelper;
@@ -10,6 +11,12 @@ use yii\web\HttpException;
 
 class RedirectsService extends Component
 {
+	protected $craft;
+	
+	public function __construct()
+	{
+		$this->craft = Craft::$app;
+	}
 
 	// Public Methods
 	// =========================================================================
@@ -73,10 +80,18 @@ class RedirectsService extends Component
 	public function findRedirectByPath ($path)
 	{
 		$redirects = $this->findAllRedirects();
+		
+		$multiSite = $this->craft->getIsMultiSite();
 
 		foreach ($redirects as $redirect)
 		{
 			$to = false;
+			
+			if ($multiSite) {
+				$siteUrlSegments = $this->getSiteUrlSegments();
+				
+				$path = $siteUrlSegments . $path;
+			}
 
 			if (trim($redirect['uri'], '/') == $path)
 			{
@@ -240,6 +255,17 @@ class RedirectsService extends Component
 		}
 
 		return false;
+	}
+	
+	private function getSiteUrlSegments()
+	{
+		$currentSite = $this->craft->getSites()->getCurrentSite();
+		
+		if ($currentSite && $currentSite->baseUrl) {
+			return str_replace('@web/', '', $currentSite->baseUrl);
+		}
+		
+		return null;
 	}
 
 }


### PR DESCRIPTION
I'm using your plugin in my project, which is a multisite/multi-language site, i.e: `@web/en` and `@web/es`. So when I entered a redirection like `en/blog/old` to `something-else`, in the comparison `en/en/blog/old` will be use.

I'm not saying this is the solution, but this is how I've fixed ti so far, maybe something so you give it a thought! 

Cheers.