### PR TITLE
Account for protocol relative URLs

### DIFF
--- a/src/Variable.php
+++ b/src/Variable.php
@@ -113,7 +113,7 @@ class Variable {
 		$transformUrl = $image->getUrl($transform);
 
 		if ($transformUrl && strpos($transformUrl, 'http') === false)
-			$transformUrl = UrlHelper::siteUrl($transformUrl);
+			$transformUrl = UrlHelper::urlWithScheme($transformUrl, (\Craft::$app->getRequest()->getIsSecureConnection()? 'https': 'http'));
 
 		return $transformUrl;
 	}


### PR DESCRIPTION
If the image URL is protocol relative, this needs to be taken into account, so that the protocol is forced onto the front of the URL.

Fixes #125