### PR TITLE
Add is_object check to $seoField

### DIFF
--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -302,7 +302,7 @@ class SitemapService extends Component
 			if ($seoFieldHandle !== null) {
 				/** @var SeoData $seoField */
 				$seoField = $item->$seoFieldHandle;
-				if ($robots = $seoField->advanced['robots'])
+				if (is_object($seoField) && $robots = $seoField->advanced['robots'])
 					if (in_array('noindex', $robots))
 						continue;
 			}


### PR DESCRIPTION
Do not know why, but sometimes the seoField object does't exists. I think it has something to do with the fact that i don't have a single as my homepage. This check fixes that the sitemap won't be generated.

yii\base\ErrorException: Trying to get property 'advanced' of non-object in /home/www.example.com/vendor/ether/seo/src/services/SitemapService.php:305