### PR TITLE
Parse environment variables from baseUrl

### DIFF
--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -162,7 +162,7 @@ class SeoField extends Field implements PreviewableFieldInterface
 		if ($craft->sites->currentSite->baseUrl) {
 			preg_match(
 				"((http?s?:\/\/)?(www.)?(.*)\/)",
-				$craft->sites->currentSite->baseUrl,
+				\Craft::parseEnv($craft->sites->currentSite->baseUrl),
 				$socialPreviewUrl
 			);
 			$socialPreviewUrl = $socialPreviewUrl[3];


### PR DESCRIPTION
This fixes an issue in 3.1 when you use environment variables to set a site's base URL
