### PR TITLE
Prevent issues with duplicate slug strings in URLs

### DIFF
--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -184,11 +184,10 @@ class SeoField extends Field implements PreviewableFieldInterface
 
 		$url = $element->getUrl();
 
-		if ($hasPreview && $isEntry && !$isHome && !$isSingle)
-			$url = substr($url, 0, strrpos( $url, '/')) . '/';
+		if ($hasPreview && $isEntry && ! $isHome && ! $isSingle && $element->slug) {
+			$url = substr($url, 0, strrpos($url, $element->slug));
+		}
 
-		if ($element->slug)
-			$url = str_replace($element->slug, '', $url);
 
 		// Social URL
 		// ---------------------------------------------------------------------


### PR DESCRIPTION
Previously if you had an entry at `https://myapp.test/test` this would be rendered in the Google preview as `https://myapp./test`.

I’ve tested this change with homepage entries, singles and nested structures and can’t see any issues.