### PR TITLE
Fixes #199 - Replace whitespace by a single space

### DIFF
--- a/resources/js/field/KeywordChecklist.js
+++ b/resources/js/field/KeywordChecklist.js
@@ -199,7 +199,7 @@ export default class KeywordChecklist {
 	 * Judge the length of the title
 	 */
 	judgeTitleLength () {
-		const l = this.SEO.snippetFields.title.textContent.trim().length;
+		const l = this.SEO.snippetFields.title.textContent.replace(/\s\s+/g, ' ').trim().length;
 		
 		this.addRating(
 			l < 40 || l > 60 ? SEO_RATING.POOR : SEO_RATING.GOOD,
@@ -215,7 +215,7 @@ export default class KeywordChecklist {
 	 * Judge the positioning of the keyword in the title
 	 */
 	judgeTitleKeyword () {
-		const title = this.SEO.snippetFields.title.textContent.trim();
+		const title = this.SEO.snippetFields.title.textContent.replace(/\s\s+/g, ' ').trim();
 		const index = title.toLowerCase().indexOf(this.keywordLower);
 		
 		if (index > -1) {


### PR DESCRIPTION
Fixes #199 .

Changes proposed in this pull request:

- This removes all whitespace, tabs, other formatting from the title and replaces it by a single space, which makes counting the length of the title correct