### PR TITLE
Graph ql fix

### DIFF
--- a/src/listeners/GetCraftQLSchema.php
+++ b/src/listeners/GetCraftQLSchema.php
@@ -33,7 +33,11 @@ class GetCraftQLSchema
 		$fieldObject->addStringField('description')->resolve(function ($root, $args) {
 			return (string)$root->getDescription()->__toString();
 		});
-		$fieldObject->addStringField('keywords');
+		$fieldObject->addStringField('keywords')->resolve(function ($root, $args) {
+			return $root->getKeywordsAsString();
+		});
+		//print_r($fieldObject->addStringField('keywords')); exit;
+		//$fieldObject->addStringField('keywords');
 		$fieldObject->addField('social')->type($socialFieldObject);
 
 		$event->schema->addField($event->sender)->type($fieldObject);

--- a/src/listeners/GetCraftQLSchema.php
+++ b/src/listeners/GetCraftQLSchema.php
@@ -16,7 +16,9 @@ class GetCraftQLSchema
 			$event->schema->createObjectType('SeoDataSocial');
 		$socialObject->addStringField('title');
 		$socialObject->addField('image')->type(VolumeInterface::class);
-		$socialObject->addStringField('description');
+		$socialObject->addStringField('description')->resolve(function ($root, $args) {
+			return (string)$root->description;
+		});
 
 		$socialFieldObject =
 			$event->schema->createObjectType('SeoDataSocialField');
@@ -25,8 +27,12 @@ class GetCraftQLSchema
 
 		$fieldObject =
 			$event->schema->createObjectType('SeoData');
-		$fieldObject->addStringField('title');
-		$fieldObject->addStringField('description');
+		$fieldObject->addStringField('title')->resolve(function ($root, $args) {
+			return (string)$root->getTitle()->__toString();
+		});
+		$fieldObject->addStringField('description')->resolve(function ($root, $args) {
+			return (string)$root->getDescription()->__toString();
+		});
 		$fieldObject->addStringField('keywords');
 		$fieldObject->addField('social')->type($socialFieldObject);
 

--- a/src/models/data/SeoData.php
+++ b/src/models/data/SeoData.php
@@ -378,6 +378,19 @@ class SeoData extends BaseObject
 		return $this->advanced['canonical'];
 	}
 
+	/**
+	 * @return array|string
+	 * @throws \Throwable
+	 */
+	public function getKeywordsAsString ()
+	{
+		$onlyKeywords = [];
+		foreach($this->keywords as $keyword) {
+			$onlyKeywords[] = $keyword['keyword'];
+		}
+		return implode(', ', $onlyKeywords);
+	}
+
 	// Helpers
 	// =========================================================================
 


### PR DESCRIPTION
Fixes https://github.com/ethercreative/seo/issues/187. Replaces https://github.com/ethercreative/seo/pull/189 as keywords field still breaks in that

Changes proposed in this pull request:

- Fixed craftql implementation for title/description and keyword fields which were breaking fields
- Added getKeywordsAsString() to retrieve the keywords. May be better to return this as a object as the rating information is currently being lost but keywords as comma separated string should be find for most use cases
