### PR TITLE
fix js error in #228

### DIFF
--- a/src/templates/_seo/fieldtype.twig
+++ b/src/templates/_seo/fieldtype.twig
@@ -107,9 +107,7 @@
 
 					<span class="seo--snippet-url">
 						{{ url and url != '/' ? url : siteUrl }}
-						{%- if not isHome and not isSingle -%}
-							<span id="{{ id }}Slug">...</span>
-						{% endif %}
+						<span id="{{ id }}Slug">...</span>
 					</span>
 
 					<textarea


### PR DESCRIPTION
Fixes #228.

I honestly don't know what line 110 and 112 are good for, but when I remove them I don't get any JS exceptions any more and can edit SEO fields again…