### PR TITLE
Add option to remove alternative URLs from sitemap

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -19,6 +19,9 @@ class Settings extends Model
 	/** @var int */
 	public $sitemapLimit = 1000;
 
+	/** @var boolean */
+	public $removeAlternateUrls = false;
+
 	// Variables: Field Type
 	// -------------------------------------------------------------------------
 
@@ -112,6 +115,10 @@ xyzzy;
 				['socialImage'],
 				'each', 'rule' => ['integer']
 			],
+            [
+                ['removeAlternateUrls'],
+                'boolean'
+            ],
 		];
 	}
 

--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -353,30 +353,31 @@ class SitemapService extends Component
 				[]
 			);
 
-			foreach ($item->supportedSites as $siteId)
-			{
-				$id = is_numeric($siteId) ? $siteId : $siteId['siteId'];
-				$site = $id ? $craft->sites->getSiteById($id) : \Craft::$app->sites->currentSite;
-				$lang = $site->language;
+            if (! $settings->removeAlternateUrls) {
+                foreach ($item->supportedSites as $siteId) {
+                    $id = is_numeric($siteId) ? $siteId : $siteId['siteId'];
+                    $site = $id ? $craft->sites->getSiteById($id) : \Craft::$app->sites->currentSite;
+                    $lang = $site->language;
 
-				if (!in_array($lang, $availableLocales))
-					continue;
+                    if (!in_array($lang, $availableLocales))
+                        continue;
 
-				if (!array_key_exists($id, $enabledLookup))
-					continue;
+                    if (!array_key_exists($id, $enabledLookup))
+                        continue;
 
-				$link = UrlHelper::siteUrl($enabledLookup[$id], null, null, $id);
+                    $link = UrlHelper::siteUrl($enabledLookup[$id], null, null, $id);
 
-				$alt = $this->_document->createElement('xhtml:link');
-				$alt->setAttribute('rel', 'alternate');
-				$alt->setAttribute(
-					'hreflang',
-					str_replace('_', '-', $lang)
-				);
-				$alt->setAttribute('href', $link);
+                    $alt = $this->_document->createElement('xhtml:link');
+                    $alt->setAttribute('rel', 'alternate');
+                    $alt->setAttribute(
+                        'hreflang',
+                        str_replace('_', '-', $lang)
+                    );
+                    $alt->setAttribute('href', $link);
 
-				$url->appendChild($alt);
-			}
+                    $url->appendChild($alt);
+                }
+            }
 		}
 
 		out:

--- a/src/templates/_settings/sitemap.twig
+++ b/src/templates/_settings/sitemap.twig
@@ -16,3 +16,12 @@
 	id: "sitemapLimit",
 	value: settings.sitemapLimit
 }) }}
+
+{{ forms.lightswitchField({
+	label: "Remove alternate URLs from sitemap",
+	instructions: "If you check this checkbox, the alternate URLs will be removed from the sitemap",
+	id: "removeAlternateUrls",
+	name: "removeAlternateUrls",
+	on: settings.removeAlternateUrls,
+	errors: settings.getErrors("removeAlternateUrls"),
+}) }}


### PR DESCRIPTION
Using alternative locales / URLs in a sitemap is very opinionated because some SEO experts recommend to add alternative URLs through link hreflang in the HTML head instead of adding alternative URLs to the sitemap. They say using both options is not recommended.

Closes #261 