### PR TITLE
Update meta.twig og:image:height

### DIFF
--- a/src/templates/_seo/meta.twig
+++ b/src/templates/_seo/meta.twig
@@ -18,7 +18,7 @@
 	<meta property="og:title" content="{{ fb.title }}" />
 	<meta property="og:image" content="{{ craft.seo.facebookImage(fb.image) }}" />
 	<meta property="og:image:width" content="1200" />
-	<meta property="og:image:height" content="600" />
+	<meta property="og:image:height" content="630" />
 	<meta property="og:description" content="{{ fb.description }}" />
 	<meta property="og:site_name" content="{{ siteName }}" />
 	<meta property="og:locale" content="{{ locale|replace('-', '_') }}" />


### PR DESCRIPTION
Facebook advise images be 1200px by 630px to keep to their 1.91:1 aspect ratio to prevent unexpected resizing and cropping.
https://developers.facebook.com/docs/sharing/webmasters/images/

Changes proposed in this pull request:
- Update og:image:height value