### PR TITLE
Update Facebook Image transform height

### DIFF
--- a/src/web/twig/Variable.php
+++ b/src/web/twig/Variable.php
@@ -71,7 +71,7 @@ class Variable
 	{
 		return $this->_socialImage($image, [
 			'width'  => 1200,
-			'height' => 600,
+			'height' => 630,
 		]);
 	}
 


### PR DESCRIPTION
To comply with Facebook's current image dimension guidelines the image transform should be 1200px by 630px.

Changes proposed in this pull request:
- Update Facebook image transform height to 630 from 600 