### PR TITLE
Add gql field-type definition for Craft 3.3 GraphQL implementation

### DIFF
--- a/src/Seo.php
+++ b/src/Seo.php
@@ -18,7 +18,10 @@ use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
 use ether\seo\fields\SeoField;
+use ether\seo\gql\SeoAdvanced;
 use ether\seo\gql\SeoData;
+use ether\seo\gql\SeoSocialData;
+use ether\seo\gql\SeoSocialNetworks;
 use ether\seo\integrations\craftql\GetCraftQLSchema;
 use ether\seo\models\Settings;
 use ether\seo\services\RedirectsService;
@@ -114,8 +117,11 @@ class Seo extends Plugin
 		);
 
 		// GraphQL type
-        Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_TYPES, function(RegisterGqlTypesEvent $event) {
+        Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_TYPES, static function(RegisterGqlTypesEvent $event) {
             $event->types[] = SeoData::class;
+            $event->types[] = SeoAdvanced::class;
+            $event->types[] = SeoSocialData::class;
+            $event->types[] = SeoSocialNetworks::class;
         });
 
 		// Variable

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -18,7 +18,7 @@ use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
 use ether\seo\fields\SeoField;
-use ether\seo\gql\SeoData;
+use ether\seo\gql\SeoDataType;
 use ether\seo\integrations\craftql\GetCraftQLSchema;
 use ether\seo\models\Settings;
 use ether\seo\services\RedirectsService;
@@ -116,7 +116,7 @@ class Seo extends Plugin
 		// GraphQL type
         Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_TYPES, function(RegisterGqlTypesEvent $event) {
             // Add my GraphQL types
-            $event->types[] = SeoData::class;
+            $event->types[] = SeoDataType::class;
         });
 
 		// Variable

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -7,8 +7,10 @@ use craft\events\ExceptionEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterUserPermissionsEvent;
+use craft\events\RegisterGqlTypesEvent;
 use craft\helpers\UrlHelper;
 use craft\services\Fields;
+use craft\services\Gql;
 use craft\services\UserPermissions;
 use craft\web\Application;
 use craft\web\ErrorHandler;
@@ -16,6 +18,7 @@ use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
 use ether\seo\fields\SeoField;
+use ether\seo\gql\SeoData;
 use ether\seo\integrations\craftql\GetCraftQLSchema;
 use ether\seo\models\Settings;
 use ether\seo\services\RedirectsService;
@@ -109,6 +112,12 @@ class Seo extends Plugin
 			Fields::EVENT_REGISTER_FIELD_TYPES,
 			[$this, 'onRegisterFieldTypes']
 		);
+
+		// GraphQL type
+        Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_TYPES, function(RegisterGqlTypesEvent $event) {
+            // Add my GraphQL types
+            $event->types[] = SeoData::class;
+        });
 
 		// Variable
 		Event::on(

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -18,7 +18,7 @@ use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
 use ether\seo\fields\SeoField;
-use ether\seo\gql\SeoDataType;
+use ether\seo\gql\SeoData;
 use ether\seo\integrations\craftql\GetCraftQLSchema;
 use ether\seo\models\Settings;
 use ether\seo\services\RedirectsService;
@@ -115,8 +115,7 @@ class Seo extends Plugin
 
 		// GraphQL type
         Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_TYPES, function(RegisterGqlTypesEvent $event) {
-            // Add my GraphQL types
-            $event->types[] = SeoDataType::class;
+            $event->types[] = SeoData::class;
         });
 
 		// Variable

--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -95,12 +95,14 @@ class SeoField extends Field implements PreviewableFieldInterface
 	}
 
     /**
-     * @return \GraphQL\Type\Definition\Type
-     * @throws GqlException
+     * @return array
      */
-	public function getContentGqlType (): \GraphQL\Type\Definition\Type
+	public function getContentGqlType (): array
     {
-        return TypeLoader::loadType('SeoData');
+        return [
+            'name' => $this->handle,
+            'type' => \ether\seo\gql\SeoData::getType(),
+        ];
     }
 
 	public function normalizeValue ($value, ElementInterface $element = null)

--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -92,6 +92,11 @@ class SeoField extends Field implements PreviewableFieldInterface
 		return Schema::TYPE_TEXT;
 	}
 
+	public function getContentGqlType (): \GraphQL\Type\Definition\Type
+    {
+        return new \ether\seo\gql\SeoData;
+    }
+
 	public function normalizeValue ($value, ElementInterface $element = null)
 	{
 		if ($value instanceof SeoData)

--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -8,6 +8,7 @@ use craft\base\PreviewableFieldInterface;
 use craft\elements\Category;
 use craft\elements\Entry;
 use craft\elements\GlobalSet;
+use craft\gql\TypeLoader;
 use craft\helpers\Json;
 use craft\models\Section;
 use ether\seo\models\data\SeoData;
@@ -94,7 +95,10 @@ class SeoField extends Field implements PreviewableFieldInterface
 
 	public function getContentGqlType (): \GraphQL\Type\Definition\Type
     {
-        return new \ether\seo\gql\SeoData;
+        // @TODO perhaps maybe definititely move this.
+        TypeLoader::registerType('SeoData', function() { return new \ether\seo\gql\SeoData; });
+
+        return TypeLoader::loadType('SeoData');
     }
 
 	public function normalizeValue ($value, ElementInterface $element = null)

--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -8,6 +8,7 @@ use craft\base\PreviewableFieldInterface;
 use craft\elements\Category;
 use craft\elements\Entry;
 use craft\elements\GlobalSet;
+use craft\errors\GqlException;
 use craft\gql\TypeLoader;
 use craft\helpers\Json;
 use craft\models\Section;
@@ -93,11 +94,12 @@ class SeoField extends Field implements PreviewableFieldInterface
 		return Schema::TYPE_TEXT;
 	}
 
+    /**
+     * @return \GraphQL\Type\Definition\Type
+     * @throws GqlException
+     */
 	public function getContentGqlType (): \GraphQL\Type\Definition\Type
     {
-        // @TODO perhaps maybe definititely move this.
-        TypeLoader::registerType('SeoData', function() { return new \ether\seo\gql\SeoData; });
-
         return TypeLoader::loadType('SeoData');
     }
 

--- a/src/gql/SeoAdvanced.php
+++ b/src/gql/SeoAdvanced.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ether\seo\gql;
+
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Class SeoAdvanced
+ *
+ * @package ether\seo\gql
+ */
+class SeoAdvanced extends \craft\gql\base\ObjectType
+{
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
+    }
+
+    /**
+     * @return ObjectType
+     */
+    public static function getType(): ObjectType
+    {
+        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'description' => 'Robots and canonical data',
+            'fields' => [
+                'robots' => Type::listOf(Type::string()),
+                'canonical' => Type::string()
+            ]
+        ]));
+    }
+}

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -2,10 +2,34 @@
 namespace ether\seo\gql;
 
 use craft\base\VolumeInterface;
+use craft\gql\base\InterfaceType;
 use craft\gql\interfaces\elements\Asset as AssetInterface;
 use craft\gql\types\elements\Asset;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+
+class SeoDataType extends InterfaceType {
+
+    /**
+     * Returns the schema object name
+     *
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return 'SeoData';
+    }
+
+    /**
+     * Returns the associated type generator class.
+     *
+     * @return string
+     */
+    public static function getTypeGenerator(): string
+    {
+        return SeoData::class;
+    }
+}
 
 class SeoData extends ObjectType
 {

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -1,0 +1,58 @@
+<?php
+namespace ether\seo\gql;
+
+use craft\base\VolumeInterface;
+use craft\gql\interfaces\elements\Asset as AssetInterface;
+use craft\gql\types\elements\Asset;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+class SeoData extends ObjectType
+{
+    public function __construct()
+    {
+        $socialFieldObject = new ObjectType([
+            'name' => 'Seo Social Data',
+            'description' => 'Social data for an individual Social network',
+            'fields' => [
+                'title' => [
+                    'type' => Type::string(),
+                    'resolve' => static function($value) { return html_entity_decode($value); }
+                ],
+                'image' => [
+                    'type' => AssetInterface::getType(),
+                ],
+                'description' => [
+                    'type' => Type::string(),
+                    'resolve' => static function($value) { return html_entity_decode($value); }
+                ]
+            ]
+        ]);
+
+        $config = [
+            // Note: 'name' is not needed in this form:
+            // it will be inferred from class name by omitting namespace and dropping "Type" suffix
+            'fields' => [
+                'title' => [
+                    'type' => Type::string(),
+                    'resolve' => static function($value) { return html_entity_decode($value); }
+                ],
+                'description' => [
+                    'type' => Type::string(),
+                    'resolve' => static function($value) { return html_entity_decode($value); }
+                ],
+                'keywords' => Type::listOf(new ObjectType([
+                    'name' => 'SEO Keyword definition',
+                    'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
+                ])),
+                'social' => new ObjectType([
+                    'twitter' => $socialFieldObject,
+                    'facebook' => $socialFieldObject
+                ]),
+
+
+            ]
+        ];
+        parent::__construct($config);
+    }
+}

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -1,13 +1,11 @@
 <?php
 namespace ether\seo\gql;
 
-use craft\base\VolumeInterface;
-use craft\gql\base\InterfaceType;
 use craft\gql\GqlEntityRegistry;
 use craft\gql\interfaces\elements\Asset as AssetInterface;
-use craft\gql\types\elements\Asset;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use craft\helpers\Gql;
 
 class SeoData extends \craft\gql\base\ObjectType
 {
@@ -16,33 +14,17 @@ class SeoData extends \craft\gql\base\ObjectType
      */
     public static function getName(): string
     {
-        return 'SeoData2';
+        return self::class;
     }
 
     /**
      * @inheritdoc
      */
-    public static function getType(): self
+    public static function getType(): Type
     {
         if ($type = GqlEntityRegistry::getEntity(self::class)) {
             return $type;
         }
-
-        $socialFieldObject = new ObjectType([
-            'name' => 'SEO Social Data',
-            'description' => 'Social data for an individual Social network',
-            'fields' => [
-                'title' => [
-                    'type' => Type::string(),
-                ],
-                'image' => [
-                    'type' => AssetInterface::getType(),
-                ],
-                'description' => [
-                    'type' => Type::string(),
-                ]
-            ]
-        ]);
 
         return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
             'name' => static::getName(),
@@ -57,12 +39,95 @@ class SeoData extends \craft\gql\base\ObjectType
                     'name' => 'SEO Keyword',
                     'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
                 ])),
-                'social' => new ObjectType([
-                    'name' => 'SEO social',
-                    'twitter' => $socialFieldObject,
-                    'facebook' => $socialFieldObject
-                ]),
+                'social' => SeoSocialNetworks::getType()
             ]
         ]));
+    }
+}
+
+class SeoSocialNetworks extends \craft\gql\base\ObjectType {
+    /**
+     * @inheritdoc
+     */
+    public static function getName(): string
+    {
+        return self::class;
+    }
+
+    public static function getType(): ObjectType {
+        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'fields' => [
+                'twitter' => SeoSocialData::getType(),
+                'facebook' => SeoSocialData::getType()
+            ]
+        ]));
+    }
+
+}
+
+
+class SeoSocialData extends \craft\gql\base\ObjectType {
+    /**
+     * @inheritdoc
+     */
+    public static function getName(): string
+    {
+        return self::class;
+    }
+
+    public static function getType(): ObjectType {
+        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'description' => 'Social data for an individual Social network',
+            'fields' => array_merge(self::getConditionalFields(), [
+                'title' => [
+                    'type' => Type::string(),
+                ],
+                'description' => [
+                    'type' => Type::string(),
+                ]
+            ])
+        ]));
+    }
+
+    /**
+     * Get fields which may only be used depending on the craft Gql config
+     */
+    protected static function getConditionalFields(): array
+    {
+        // Images may be in any public volume, so verify them all.
+        $volumes = \Craft::$app->volumes->getPublicVolumes();
+        $awareOfAllPublicVolumes = false;
+
+        if (!empty($volumes)) {
+            foreach ($volumes as $volume) {
+                if (!Gql::isSchemaAwareOf('volumes.' . $volume->uid)) {
+                    $awareOfAllPublicVolumes = false;
+                    break;
+                } else {
+                    $awareOfAllPublicVolumes = true;
+                }
+            }
+        }
+
+        if ($awareOfAllPublicVolumes) {
+            return [
+                'image' => [
+                    'name' => 'image',
+                    'type' => AssetInterface::getType(),
+                ]
+            ];
+        }
+
+        return [];
     }
 }

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -5,6 +5,7 @@ use craft\base\VolumeInterface;
 use craft\gql\base\InterfaceType;
 use craft\gql\interfaces\elements\Asset as AssetInterface;
 use craft\gql\types\elements\Asset;
+use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 
 class SeoData extends \craft\gql\base\ObjectType
@@ -22,7 +23,7 @@ class SeoData extends \craft\gql\base\ObjectType
      */
     public static function getType(): self
     {
-        $socialFieldObject = new self([
+        $socialFieldObject = new ObjectType([
             'name' => 'SEO Social Data',
             'description' => 'Social data for an individual Social network',
             'fields' => [
@@ -51,11 +52,11 @@ class SeoData extends \craft\gql\base\ObjectType
                     'type' => Type::string(),
                     'resolve' => static function($value) { return html_entity_decode($value); }
                 ],
-                'keywords' => Type::listOf(new self([
+                'keywords' => Type::listOf(new ObjectType([
                     'name' => 'SEO Keyword',
                     'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
                 ])),
-                'social' => new self([
+                'social' => new ObjectType([
                     'name' => 'SEO social',
                     'twitter' => $socialFieldObject,
                     'facebook' => $socialFieldObject

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace ether\seo\gql;
 
 use craft\gql\GqlEntityRegistry;
@@ -13,18 +16,24 @@ use craft\helpers\Gql;
  */
 class SeoData extends \craft\gql\base\ObjectType
 {
+    /**
+     * @return string
+     */
     public static function getName(): string
     {
         return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
     }
 
+    /**
+     * @return Type
+     */
     public static function getType(): Type
     {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+        if ($type = GqlEntityRegistry::getEntity(static::class)) {
             return $type;
         }
 
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
+        return GqlEntityRegistry::createEntity(static::class, new \GraphQL\Type\Definition\ObjectType([
             'name' => static::getName(),
             'fields' => [
                 'title' => [
@@ -39,124 +48,6 @@ class SeoData extends \craft\gql\base\ObjectType
                 ])),
                 'social' => SeoSocialNetworks::getType(),
                 'advanced' => SeoAdvanced::getType(),
-            ]
-        ]));
-    }
-}
-
-/**
- * Class SeoSocialNetworks
- * @package ether\seo\gql
- */
-class SeoSocialNetworks extends \craft\gql\base\ObjectType
-{
-    public static function getName(): string
-    {
-        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
-    }
-
-    public static function getType(): ObjectType {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
-            return $type;
-        }
-
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
-            'name' => static::getName(),
-            'fields' => [
-                'twitter' => SeoSocialData::getType(),
-                'facebook' => SeoSocialData::getType()
-            ]
-        ]));
-    }
-
-}
-
-/**
- * Class SeoSocialData
- * @package ether\seo\gql
- */
-class SeoSocialData extends \craft\gql\base\ObjectType
-{
-    public static function getName(): string
-    {
-        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
-    }
-
-    /**
-     * @return ObjectType
-     * @throws \craft\errors\GqlException
-     */
-    public static function getType(): ObjectType {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
-            return $type;
-        }
-
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
-            'name' => static::getName(),
-            'description' => 'Social data for an individual Social network',
-            'fields' => array_merge(self::getConditionalFields(), [
-                'title' => [
-                    'type' => Type::string(),
-                ],
-                'description' => [
-                    'type' => Type::string(),
-                ]
-            ])
-        ]));
-    }
-
-    /**
-     * Get fields which may only be used depending on the craft Gql config
-     * @throws \craft\errors\GqlException
-     */
-    protected static function getConditionalFields(): array
-    {
-        // Images may be in any public volume, so verify them all.
-        $volumes = \Craft::$app->volumes->getPublicVolumes();
-        $awareOfAllPublicVolumes = false;
-
-        if (!empty($volumes)) {
-            foreach ($volumes as $volume) {
-                if (!Gql::isSchemaAwareOf('volumes.' . $volume->uid)) {
-                    $awareOfAllPublicVolumes = false;
-                    break;
-                }
-
-                $awareOfAllPublicVolumes = true;
-            }
-        }
-
-        if ($awareOfAllPublicVolumes) {
-            return [
-                'image' => [
-                    'name' => 'image',
-                    'type' => AssetInterface::getType(),
-                ]
-            ];
-        }
-        return [];
-    }
-}
-
-class SeoAdvanced extends \craft\gql\base\ObjectType
-{
-    public static function getName(): string
-    {
-        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
-    }
-
-    public static function getType(): ObjectType
-    {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
-            return $type;
-        }
-
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
-            'name' => static::getName(),
-            'description' => 'Robots and canonical data',
-            'fields' => [
-                'robots' => Type::listOf(Type::string()),
-                'canonical' => Type::string()
             ]
         ]));
     }

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -12,7 +12,7 @@ class SeoData extends ObjectType
     public function __construct()
     {
         $socialFieldObject = new ObjectType([
-            'name' => 'Seo Social Data',
+            'name' => 'SEO Social Data',
             'description' => 'Social data for an individual Social network',
             'fields' => [
                 'title' => [
@@ -42,10 +42,11 @@ class SeoData extends ObjectType
                     'resolve' => static function($value) { return html_entity_decode($value); }
                 ],
                 'keywords' => Type::listOf(new ObjectType([
-                    'name' => 'SEO Keyword definition',
+                    'name' => 'SEO Keyword',
                     'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
                 ])),
                 'social' => new ObjectType([
+                    'name' => 'SEO social',
                     'twitter' => $socialFieldObject,
                     'facebook' => $socialFieldObject
                 ]),

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -5,7 +5,6 @@ use craft\base\VolumeInterface;
 use craft\gql\base\InterfaceType;
 use craft\gql\interfaces\elements\Asset as AssetInterface;
 use craft\gql\types\elements\Asset;
-use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 
 class SeoData extends \craft\gql\base\ObjectType
@@ -21,9 +20,9 @@ class SeoData extends \craft\gql\base\ObjectType
     /**
      * @inheritdoc
      */
-    public static function getType(): ObjectType
+    public static function getType(): self
     {
-        $socialFieldObject = new ObjectType([
+        $socialFieldObject = new self([
             'name' => 'SEO Social Data',
             'description' => 'Social data for an individual Social network',
             'fields' => [
@@ -41,7 +40,7 @@ class SeoData extends \craft\gql\base\ObjectType
             ]
         ]);
 
-        return new ObjectType([
+        return new self([
             'name' => static::getName(),
             'fields' => [
                 'title' => [
@@ -52,11 +51,11 @@ class SeoData extends \craft\gql\base\ObjectType
                     'type' => Type::string(),
                     'resolve' => static function($value) { return html_entity_decode($value); }
                 ],
-                'keywords' => Type::listOf(new ObjectType([
+                'keywords' => Type::listOf(new self([
                     'name' => 'SEO Keyword',
                     'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
                 ])),
-                'social' => new ObjectType([
+                'social' => new self([
                     'name' => 'SEO social',
                     'twitter' => $socialFieldObject,
                     'facebook' => $socialFieldObject

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -34,7 +34,7 @@ class SeoData extends \craft\gql\base\ObjectType
                     'type' => Type::string(),
                 ],
                 'keywords' => Type::listOf(new ObjectType([
-                    'name' => 'SEO Keyword',
+                    'name' => 'Ether_SEOKeyword',
                     'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
                 ])),
                 'social' => SeoSocialNetworks::getType(),

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -7,19 +7,17 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use craft\helpers\Gql;
 
+/**
+ * Class SeoData
+ * @package ether\seo\gql
+ */
 class SeoData extends \craft\gql\base\ObjectType
 {
-    /**
-     * @inheritdoc
-     */
     public static function getName(): string
     {
         return self::class;
     }
 
-    /**
-     * @inheritdoc
-     */
     public static function getType(): Type
     {
         if ($type = GqlEntityRegistry::getEntity(self::class)) {
@@ -39,16 +37,19 @@ class SeoData extends \craft\gql\base\ObjectType
                     'name' => 'SEO Keyword',
                     'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
                 ])),
-                'social' => SeoSocialNetworks::getType()
+                'social' => SeoSocialNetworks::getType(),
+                'advanced' => SeoAdvanced::getType(),
             ]
         ]));
     }
 }
 
-class SeoSocialNetworks extends \craft\gql\base\ObjectType {
-    /**
-     * @inheritdoc
-     */
+/**
+ * Class SeoSocialNetworks
+ * @package ether\seo\gql
+ */
+class SeoSocialNetworks extends \craft\gql\base\ObjectType
+{
     public static function getName(): string
     {
         return self::class;
@@ -70,16 +71,21 @@ class SeoSocialNetworks extends \craft\gql\base\ObjectType {
 
 }
 
-
-class SeoSocialData extends \craft\gql\base\ObjectType {
-    /**
-     * @inheritdoc
-     */
+/**
+ * Class SeoSocialData
+ * @package ether\seo\gql
+ */
+class SeoSocialData extends \craft\gql\base\ObjectType
+{
     public static function getName(): string
     {
         return self::class;
     }
 
+    /**
+     * @return ObjectType
+     * @throws \craft\errors\GqlException
+     */
     public static function getType(): ObjectType {
         if ($type = GqlEntityRegistry::getEntity(self::class)) {
             return $type;
@@ -101,6 +107,7 @@ class SeoSocialData extends \craft\gql\base\ObjectType {
 
     /**
      * Get fields which may only be used depending on the craft Gql config
+     * @throws \craft\errors\GqlException
      */
     protected static function getConditionalFields(): array
     {
@@ -113,9 +120,9 @@ class SeoSocialData extends \craft\gql\base\ObjectType {
                 if (!Gql::isSchemaAwareOf('volumes.' . $volume->uid)) {
                     $awareOfAllPublicVolumes = false;
                     break;
-                } else {
-                    $awareOfAllPublicVolumes = true;
                 }
+
+                $awareOfAllPublicVolumes = true;
             }
         }
 
@@ -127,7 +134,30 @@ class SeoSocialData extends \craft\gql\base\ObjectType {
                 ]
             ];
         }
-
         return [];
+    }
+}
+
+class SeoAdvanced extends \craft\gql\base\ObjectType
+{
+    public static function getName(): string
+    {
+        return self::class;
+    }
+
+    public static function getType(): ObjectType
+    {
+        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'description' => 'Robots and canonical data',
+            'fields' => [
+                'robots' => Type::listOf(Type::string()),
+                'canonical' => Type::string()
+            ]
+        ]));
     }
 }

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -8,12 +8,10 @@ use craft\gql\types\elements\Asset;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 
-class SeoDataType extends InterfaceType {
-
+class SeoData extends \craft\gql\base\ObjectType
+{
     /**
-     * Returns the schema object name
-     *
-     * @return string
+     * @inheritdoc
      */
     public static function getName(): string
     {
@@ -21,19 +19,9 @@ class SeoDataType extends InterfaceType {
     }
 
     /**
-     * Returns the associated type generator class.
-     *
-     * @return string
+     * @inheritdoc
      */
-    public static function getTypeGenerator(): string
-    {
-        return SeoData::class;
-    }
-}
-
-class SeoData extends ObjectType
-{
-    public function __construct()
+    public function getType(): ObjectType
     {
         $socialFieldObject = new ObjectType([
             'name' => 'SEO Social Data',
@@ -53,7 +41,7 @@ class SeoData extends ObjectType
             ]
         ]);
 
-        $config = [
+        return new ObjectType([
             // Note: 'name' is not needed in this form:
             // it will be inferred from class name by omitting namespace and dropping "Type" suffix
             'fields' => [
@@ -74,10 +62,7 @@ class SeoData extends ObjectType
                     'twitter' => $socialFieldObject,
                     'facebook' => $socialFieldObject
                 ]),
-
-
             ]
-        ];
-        parent::__construct($config);
+        ]);
     }
 }

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -42,8 +42,7 @@ class SeoData extends \craft\gql\base\ObjectType
         ]);
 
         return new ObjectType([
-            // Note: 'name' is not needed in this form:
-            // it will be inferred from class name by omitting namespace and dropping "Type" suffix
+            'name' => static::getName(),
             'fields' => [
                 'title' => [
                     'type' => Type::string(),

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -21,7 +21,7 @@ class SeoData extends \craft\gql\base\ObjectType
     /**
      * @inheritdoc
      */
-    public function getType(): ObjectType
+    public static function getType(): ObjectType
     {
         $socialFieldObject = new ObjectType([
             'name' => 'SEO Social Data',

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -3,6 +3,7 @@ namespace ether\seo\gql;
 
 use craft\base\VolumeInterface;
 use craft\gql\base\InterfaceType;
+use craft\gql\GqlEntityRegistry;
 use craft\gql\interfaces\elements\Asset as AssetInterface;
 use craft\gql\types\elements\Asset;
 use GraphQL\Type\Definition\ObjectType;
@@ -15,7 +16,7 @@ class SeoData extends \craft\gql\base\ObjectType
      */
     public static function getName(): string
     {
-        return 'SeoData';
+        return 'SeoData2';
     }
 
     /**
@@ -23,34 +24,34 @@ class SeoData extends \craft\gql\base\ObjectType
      */
     public static function getType(): self
     {
+        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+            return $type;
+        }
+
         $socialFieldObject = new ObjectType([
             'name' => 'SEO Social Data',
             'description' => 'Social data for an individual Social network',
             'fields' => [
                 'title' => [
                     'type' => Type::string(),
-                    'resolve' => static function($value) { return html_entity_decode($value); }
                 ],
                 'image' => [
                     'type' => AssetInterface::getType(),
                 ],
                 'description' => [
                     'type' => Type::string(),
-                    'resolve' => static function($value) { return html_entity_decode($value); }
                 ]
             ]
         ]);
 
-        return new self([
+        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
             'name' => static::getName(),
             'fields' => [
                 'title' => [
                     'type' => Type::string(),
-                    'resolve' => static function($value) { return html_entity_decode($value); }
                 ],
                 'description' => [
                     'type' => Type::string(),
-                    'resolve' => static function($value) { return html_entity_decode($value); }
                 ],
                 'keywords' => Type::listOf(new ObjectType([
                     'name' => 'SEO Keyword',
@@ -62,6 +63,6 @@ class SeoData extends \craft\gql\base\ObjectType
                     'facebook' => $socialFieldObject
                 ]),
             ]
-        ]);
+        ]));
     }
 }

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -15,7 +15,7 @@ class SeoData extends \craft\gql\base\ObjectType
 {
     public static function getName(): string
     {
-        return self::class;
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
     }
 
     public static function getType(): Type
@@ -52,7 +52,7 @@ class SeoSocialNetworks extends \craft\gql\base\ObjectType
 {
     public static function getName(): string
     {
-        return self::class;
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
     }
 
     public static function getType(): ObjectType {
@@ -79,7 +79,7 @@ class SeoSocialData extends \craft\gql\base\ObjectType
 {
     public static function getName(): string
     {
-        return self::class;
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
     }
 
     /**
@@ -142,7 +142,7 @@ class SeoAdvanced extends \craft\gql\base\ObjectType
 {
     public static function getName(): string
     {
-        return self::class;
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
     }
 
     public static function getType(): ObjectType

--- a/src/gql/SeoSocialData.php
+++ b/src/gql/SeoSocialData.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ether\seo\gql;
+
+use craft\gql\GqlEntityRegistry;
+use craft\gql\interfaces\elements\Asset as AssetInterface;
+use craft\helpers\Gql;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Class SeoSocialData
+ *
+ * @package ether\seo\gql
+ */
+class SeoSocialData extends \craft\gql\base\ObjectType
+{
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
+    }
+
+    /**
+     * @return ObjectType
+     * @throws \craft\errors\GqlException
+     */
+    public static function getType(): ObjectType
+    {
+        if ($type = GqlEntityRegistry::getEntity(static::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(static::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'description' => 'Social data for an individual Social network',
+            'fields' => array_merge(static::getConditionalFields(), [
+                'title' => [
+                    'type' => Type::string(),
+                ],
+                'description' => [
+                    'type' => Type::string(),
+                ]
+            ])
+        ]));
+    }
+
+    /**
+     * Get fields which may only be used depending on the craft Gql config
+     *
+     * @throws \craft\errors\GqlException
+     */
+    protected static function getConditionalFields(): array
+    {
+        // Images may be in any public volume, so verify them all.
+        $volumes = \Craft::$app->volumes->getPublicVolumes();
+        $awareOfAllPublicVolumes = false;
+
+        if (!empty($volumes)) {
+            foreach ($volumes as $volume) {
+                if (!Gql::isSchemaAwareOf('volumes.' . $volume->uid)) {
+                    $awareOfAllPublicVolumes = false;
+                    break;
+                }
+
+                $awareOfAllPublicVolumes = true;
+            }
+        }
+
+        if ($awareOfAllPublicVolumes) {
+            return [
+                'image' => [
+                    'name' => 'image',
+                    'type' => AssetInterface::getType(),
+                ]
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/gql/SeoSocialNetworks.php
+++ b/src/gql/SeoSocialNetworks.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ether\seo\gql;
+
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\ObjectType;
+
+/**
+ * Class SeoSocialNetworks
+ *
+ * @package ether\seo\gql
+ */
+class SeoSocialNetworks extends \craft\gql\base\ObjectType
+{
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
+    }
+
+    /**
+     * @return ObjectType
+     * @throws \craft\errors\GqlException
+     */
+    public static function getType(): ObjectType
+    {
+        if ($type = GqlEntityRegistry::getEntity(static::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(static::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'fields' => [
+                'twitter' => SeoSocialData::getType(),
+                'facebook' => SeoSocialData::getType()
+            ]
+        ]));
+    }
+}


### PR DESCRIPTION
Fixes #255   .

Changes proposed in this pull request:

- Adds new types for all the different objects in the SEO plugin
- Registers the types with the Craft gql registry

Note: This needs some further testing before it can be considered stable. We're currently using this fork in one of our projects, but would appreciate some further help :)