### PR TITLE
Fix an exception when an entry type has multiple SEO fields

### DIFF
--- a/src/models/data/SeoData.php
+++ b/src/models/data/SeoData.php
@@ -436,7 +436,7 @@ class SeoData extends BaseObject
 		{
 			foreach ($this->_element->attributes() as $name)
 				if ($name !== $this->_handle)
-					$variables[$name] = $this->_element->$name;
+					$variables[$name] = $this->_element->$name ?? null;
 
 			if (!array_key_exists('type', $variables) && $this->_element->hasMethod('getType'))
 				$variables['type'] = $this->_element->getType();


### PR DESCRIPTION
When an entry type has multiple SEO fields (I know, its a rare edge case) an exception would occur when trying to edit an entry in this section.

![Screenshot 2019-12-11 at 19 18 07](https://user-images.githubusercontent.com/353843/70648261-fb730c00-1c4a-11ea-9905-9da1a43e5481.png)

This seems to fix the issue:
  - it's now possible to edit the entry
  - the various SEO fields of the entry retain their own data when saved
  - the correct data can be obtained on the frontend for each SEO field

⚠️ I only tested and found out it works, I didn't analyse why it works and it may very well break other things. 