### PR TITLE
noindex unless on production environment.

### DIFF
--- a/src/services/SeoService.php
+++ b/src/services/SeoService.php
@@ -22,8 +22,8 @@ class SeoService extends Component
 	{
 		$headers = Craft::$app->getResponse()->getHeaders();
 
-		// If devMode always noindex
-		if (Craft::$app->config->general->devMode)
+		// Always noindex except on production environment
+		if (CRAFT_ENVIRONMENT !== 'production')
 		{
 			$headers->set('x-robots-tag', 'none, noimageindex');
 			return;


### PR DESCRIPTION
Previously, the test was on devMode but in my case (and I make this PR because
I think most people do), I want my staging environment to be as similar as
possible as my production environment, yet I don't want staging indexed by
search engines.