### PR TITLE
Fixed issue where custom SEO objects would always default to fallback image

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ When moving from your old, awful site to your shiny new Craft one, you’ll want
 
 SEO for Crafts redirect manager lets you easily add 301 & 302 redirects, with full .htaccess style regex support!
 
-Redirects support [PCRE regex syntax](http://php.net/manual/en/reference.pcre.pattern.syntax.php). By default, all `/` and `?` not inside parenthesis are escaped. To prevent any escaping include the opening and closing forward slashes and flags: `/^blog$/i`. All redirects are given the insensitive flag, unless overwritten. 
+Redirects support [PCRE regex syntax](http://php.net/manual/en/reference.pcre.pattern.syntax.php). By default, all `/` and `?` not inside parenthesis are escaped. To prevent any escaping include the opening and closing forward slashes and flags: `/^blog$/i`. All redirects are given the insensitive flag, unless overwritten.
 
 **Redirect Regex Example**  
 To redirect from `blog/2016/my-post` to `news/my-post` you would add the following redirect:
@@ -78,9 +78,10 @@ In some cases, you will not have access to an SEO field, but will want to set th
 
 ```twig
 craft.seo.custom(
-    'The Page Title', 
+    'The Page Title',
     'The page description',
-    
+    null,
+
     // Social media - Any missing fields (excluding images) will be populated by the values above
     {
         twitter: { image: myImageField.first() },

--- a/src/models/data/SocialData.php
+++ b/src/models/data/SocialData.php
@@ -107,7 +107,7 @@ class SocialData extends BaseObject
 		$image = $this->imageId;
 
 		if (is_array($image))
-			$image = $image['id'];
+			$image = $image[0]['id'];
 
 		if (empty($image))
 			$image = $this->_fallback['image'];


### PR DESCRIPTION
Found a couple issues causing custom SEO objects to always default to a fallback image even when images were defined:

1. The `custom` function has a deprecated `$_` param that is not taken into account in the **Custom SEO Object** documentation. I added a `null` in the documentation, which when implemented this way allows the social array to be properly passed to the `$social` param. Or if you're able to remove the `$_` param altogether, that would be even cleaner.
2. I think `getImage()` was trying to incorrectly access the image id. I believe it should be `$image = $image[0]['id'];`. Worked for me in my testing.

Thanks for considering these changes.