### PR TITLE
🐛 Hide the "Settings" links when admin changes are disallowed

### DIFF
--- a/src/Seo.php
+++ b/src/Seo.php
@@ -181,7 +181,7 @@ class Seo extends Plugin
 			$subNav['schema'] =
 				['label' => 'Schema', 'url' => 'seo/schema'];*/
 
-		if ($currentUser->getIsAdmin())
+		if (\Craft::$app->getConfig()->general->allowAdminChanges && $currentUser->getIsAdmin())
 			$subNav['settings'] =
 				['label' => 'Settings', 'url' => 'seo/settings'];
 

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -23,7 +23,7 @@
 				Schema
 			</a>
 		</li>#}
-		{% if currentUser.admin %}
+		{% if craft.app.config.general.allowAdminChanges and currentUser.admin %}
 			<li>
 				<a href="{{ url('seo/settings') }}"
 				   data-icon="settings"


### PR DESCRIPTION
Change proposed in this pull request:

Hide the settings CP sidebar link & CP SEO dashboard button when the Craft general setting `allowAdminChanges` is set to `false`. Before this fix, clicking one of these links with admin changes disabled lead to an error.