### PR TITLE
Set Twitter image transform to a 2:1 ratio

### DIFF
--- a/src/web/twig/Variable.php
+++ b/src/web/twig/Variable.php
@@ -57,7 +57,7 @@ class Variable
 	{
 		return $this->_socialImage($image, [
 			'width'  => 1200,
-			'height' => 675,
+			'height' => 600,
 		]);
 	}
 


### PR DESCRIPTION
Based on the [Twitter guidelines](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image), preview images should be 2:1 aspect ratio.