### PR TITLE
Fix error in retrieving preview if no SVG tags are present on the page

### DIFF
--- a/resources/js/field/EntryMarkup.js
+++ b/resources/js/field/EntryMarkup.js
@@ -55,11 +55,14 @@ class EntryMarkup {
 				let data = await this._preview();
 
 				// Remove all <svg/>, <script/> & <style/> tags
-				data.match(/<svg([^'"]|"(\\.|[^"\\])*"|'(\\.|[^'\\])*')*?<\/svg>/g).forEach(s => {
-					if (typeof s !== 'string') return;
-					const t = s.match(/<text([^'"]|"(\\.|[^"\\])*"|'(\\.|[^'\\])*')*?<\/text>/g) || [];
-					data = data.replace(s, '<svg>' + t.join() + '</svg>');
-				});
+				const svgTags = data.match(/<svg([^'"]|"(\\.|[^"\\])*"|'(\\.|[^'\\])*')*?<\/svg>/g);
+				if (svgTags) {
+					svgTags.forEach(s => {
+						if (typeof s !== 'string') return;
+						const t = s.match(/<text([^'"]|"(\\.|[^"\\])*"|'(\\.|[^'\\])*')*?<\/text>/g) || [];
+						data = data.replace(s, '<svg>' + t.join() + '</svg>');
+					});
+				}
 
 				data = data.replace(
 					/<script([^'"]|"(\\.|[^"\\])*"|'(\\.|[^'\\])*')*?<\/script>/g,


### PR DESCRIPTION
Fixes #288.

Changes proposed in this pull request:

- The javascript code would throw an error if there weren't any SVG tags on the preview page, due to the fact that `.match()` on a string can return null. Added a check before calling `.forEach()` on the resulting value.

---

cc @Tam @icreatestuff 