### PR TITLE
Update getSettingsHtml function to be compatible with Craft 3.5

### DIFF
--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -12,6 +12,7 @@ use craft\errors\GqlException;
 use craft\gql\TypeLoader;
 use craft\helpers\Json;
 use craft\helpers\UrlHelper;
+use craft\helpers\Html;
 use craft\models\Section;
 use ether\seo\models\data\SeoData;
 use ether\seo\Seo;
@@ -297,10 +298,11 @@ class SeoField extends Field implements PreviewableFieldInterface
 	public function getSettingsHtml ()
 	{
 		$view = \Craft::$app->view;
-		$namespace = $view->namespaceInputId('');
+		$namespace = $view->getNamespace();
+		$namespaceId = Html::namespaceId('', $namespace);
 
 		$view->registerAssetBundle(SeoFieldSettingsAsset::class);
-		$view->registerJs('new SeoFieldSettings("' . $namespace . '");');
+		$view->registerJs('new SeoFieldSettings("' . $namespaceId . '");');
 
 		return $view->renderTemplate(
 			'seo/_seo/settings',


### PR DESCRIPTION
Craft 3.5 updated the `$view->namespaceInputId` to return an empty string if an empty string was passed to it. This resulted in an Javascript uncaught error on the field settings page as the element with the namespaced id could not be found. Instead, we replace the `namespaceInputId` function with the `Html::namespaceId` helper function to return the value expected by the SEO plugin.

Fixes #300 

Changes proposed in this pull request:

- Replaces `namespaceInputId` function with `HTML::namespaceId` helper function in SEOField.PHP