### PR TITLE
Fixing #405 & #406: Remove version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "ether/seo",
   "license": "MIT",
   "description": "SEO utilities including a unique field type, sitemap, & redirect manager",
-  "version": "4.0.2.2",
   "type": "craft-plugin",
   "minimum-stability": "dev",
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ether/seo",
   "license": "MIT",
   "description": "SEO utilities including a unique field type, sitemap, & redirect manager",
-  "version": "4.0.0",
+  "version": "4.0.2.2",
   "type": "craft-plugin",
   "minimum-stability": "dev",
   "require": {


### PR DESCRIPTION
Fixes #405 & #406.

Removing version number in the composer.json.
See:
https://getcomposer.org/doc/04-schema.md#version