### PR TITLE
Return elements from all sites

### DIFF
--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -295,7 +295,7 @@ class SitemapService extends Component
 
 		$elements = $type::find();
 		$elements->{$idHandle} = $variables['id'];
-		$elements->siteId = Craft::$app->sites->currentSite->id;
+		$elements->siteId = '*';
 		$elements->limit = $settings->sitemapLimit;
 		$elements->offset = $settings->sitemapLimit * $variables['page'];
 


### PR DESCRIPTION
Fixes missing elements in the sitemap.

Changes proposed in this pull request:

Elements that are not part of the default site are lost in the generated sitemap.

The main sitemap index does take these lost elements into account, this results in the index deciding that there are N pages worth of elements, while these sitemaps remain empty because the sitemaps themeselves only show elements from the default site.