### PR TITLE
Fix #415 for missing dynamic custom fields

### DIFF
--- a/src/models/data/SeoData.php
+++ b/src/models/data/SeoData.php
@@ -438,7 +438,7 @@ class SeoData extends BaseObject
 
 		if ($this->_element !== null)
 		{
-			foreach ($this->_element->attributes() as $name)
+			foreach (array_keys($this->_element->fields()) as $name)
 				if ($name !== $this->_handle)
 					$variables[$name] = $this->_element->$name ?? null;
 


### PR DESCRIPTION
This PR tries to fix the #415 issue where elements custom fields are not evaluated using dynamic synthax in Craft 4.