### PR TITLE
Fix for error when using SEO field on Shopify product

### DIFF
--- a/src/fields/SeoField.php
+++ b/src/fields/SeoField.php
@@ -14,6 +14,7 @@ use craft\helpers\Json;
 use craft\helpers\UrlHelper;
 use craft\helpers\Html;
 use craft\models\Section;
+use craft\shopify\elements\Product as ShopifyProduct;
 use ether\seo\models\data\SeoData;
 use ether\seo\Seo;
 use ether\seo\web\assets\SeoFieldAsset;
@@ -243,7 +244,7 @@ class SeoField extends Field implements PreviewableFieldInterface
 
 		if ($element instanceof Category)
 			$renderData['groupId'] = $element->groupId;
-		elseif ($element instanceof GlobalSet)
+		elseif ($element instanceof GlobalSet || $element instanceof ShopifyProduct)
 			$renderData['typeId'] = null;
 		elseif ($isCalendar)
 			$renderData['calendarId'] = $element->calendarId;


### PR DESCRIPTION
Fixes an unknown property exception that occurs when using an SEO field on a [Shopify](https://plugins.craftcms.com/shopify) product, due to those products not having a `typeId`.