### PR TITLE
Fix incorrect classname

### DIFF
--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -556,12 +556,15 @@ class SitemapService extends Component
 	private function _setCriteriaIdByType ($criteria, Element $type, $id)
 	{
 		switch ($type::className()) {
+			case 'craft\\elements\\Entry':
 			case 'Entry':
 				$criteria->sectionId = $id;
 				break;
+			case 'craft\\elements\\Category':
 			case 'Category':
 				$criteria->groupId = $id;
 				break;
+			case 'craft\\elements\\Product':
 			case 'Product':
 				$criteria->typeId = $id;
 				break;


### PR DESCRIPTION
`$type::className()` returns a fully qualified name of the class, therefore, 'Entry' would never match.

This bug results in no criteria being set which results in ALL items in the database being part of the selection, making the sitemap extremely big.