### PR TITLE
fix: use pagination information on canonical (v3)

### DIFF
--- a/src/models/data/SeoData.php
+++ b/src/models/data/SeoData.php
@@ -378,7 +378,7 @@ class SeoData extends BaseObject
 	public function getCanonical ()
 	{
 		if (empty($this->advanced['canonical']))
-			return UrlHelper::siteUrl(Craft::$app->request->getPathInfo());
+			return UrlHelper::siteUrl(Craft::$app->request->getFullPath());
 
 		return UrlHelper::siteUrl($this->advanced['canonical']);
 	}


### PR DESCRIPTION
Fixes #335 

Changes proposed in this pull request:

- keep paginated info in canonical

Unless a single page is available with all links that are paginated in multiple URLs (this being the canonical page), paginated lists should be self-canonicalized. 
This PR applies to v3 of the plugin.