### PR TITLE
SitemapService: check for `uri` IS NOT NULL

### DIFF
--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -364,6 +364,7 @@ class SitemapService extends Component
 				             ->from('{{%elements_sites}}')
 				             ->where('[[elementId]] = ' . $item->id)
 				             ->andWhere('enabled = true')
+				             ->andWhere('uri IS NOT NULL')
 				             ->all();
 
 			$enabledLookup = array_reduce(


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a check for uri IS NOT NULL in query when looking up for which sites the element/item is enabled

----

I have these records in my database:
```
+---------+-----------+--------+--------------+--------------+---------+---------------------+---------------------+--------------------------------------+
| id      | elementId | siteId | slug         | uri          | enabled | dateCreated         | dateUpdated         | uid                                  |
+---------+-----------+--------+--------------+--------------+---------+---------------------+---------------------+--------------------------------------+
| 4425315 |   2370031 |      1 | met-dank-aan | met-dank-aan |       1 | 2022-08-23 08:48:18 | 2022-08-23 08:48:55 | cb78860e-3edd-4053-8b50-c3b38bf84904 |
| 4425316 |   2370031 |      2 | met-dank-aan | NULL         |       1 | 2022-08-23 08:48:19 | 2022-08-23 08:49:04 | 206f1529-5cd2-4d6f-b1eb-8a90dbde22ff |
+---------+-----------+--------+--------------+--------------+---------+---------------------+---------------------+--------------------------------------+
```

which caused the error:
> 2024-04-11 13:15:49 [web.ERROR] [TypeError] TypeError: craft\helpers\UrlHelper::siteUrl(): Argument `#1` ($path) must be of type string, null given, called in vendor/ether/seo/src/services/SitemapService.php on line 398 and defined in vendor/craftcms/cms/src/helpers/UrlHelper.php:306
Stack trace:
`#0` vendor/ether/seo/src/services/SitemapService.php(398): craft\helpers\UrlHelper::siteUrl(NULL, NULL, NULL, 2)
`#1` vendor/ether/seo/src/controllers/sitemap/XmlController.php(25): ether\seo\services\SitemapService->core(Array)
