### PR TITLE
fix: regression on multisite canonical URLs v3)

### DIFF
--- a/src/models/data/SeoData.php
+++ b/src/models/data/SeoData.php
@@ -377,8 +377,13 @@ class SeoData extends BaseObject
 	 */
 	public function getCanonical ()
 	{
-		if (empty($this->advanced['canonical']))
-			return UrlHelper::siteUrl(Craft::$app->request->getFullPath());
+		if (empty($this->advanced['canonical'])) {
+			$fullPathWithPagination = Craft::$app->request->getFullPath();
+			$pathInfo = Craft::$app->request->getPathInfo();
+			return ($subPath = strpos($fullPathWithPagination, $pathInfo . '/')) === false ?
+				UrlHelper::siteUrl($pathInfo) :
+				UrlHelper::siteUrl(substr($fullPathWithPagination, $subPath));
+		}
 
 		return UrlHelper::siteUrl($this->advanced['canonical']);
 	}


### PR DESCRIPTION
Fixes #469.

Changes proposed in this pull request:

- fixes an issue introduced with 4.2.2 on multisite installations where the language prefix in canonical URLs was repeated

This PR applies to v3 of the plugin.
